### PR TITLE
Fix: Resolved duplicate naming for different creature dwellings

### DIFF
--- a/Courtyard/Content/translation/courtyard/chinese.json
+++ b/Courtyard/Content/translation/courtyard/chinese.json
@@ -252,7 +252,7 @@
 	"mapObject.courtyard.creatureGeneratorCommon.alchemyTower.name" : "炼金塔",
 	"mapObject.courtyard.creatureGeneratorCommon.arbours.name" : "药草廊",
 	"mapObject.courtyard.creatureGeneratorCommon.arsenal.name" : "兵工厂",
-	"mapObject.courtyard.creatureGeneratorCommon.dodoBurgh.name" : "兵工厂",
+	"mapObject.courtyard.creatureGeneratorCommon.dodoBurgh.name" : "巨鸟巢",
 	"mapObject.courtyard.creatureGeneratorCommon.furnace.name" : "熔矿炉",
 	"mapObject.courtyard.creatureGeneratorCommon.marbleHall.name" : "白石厅",
 	"mapObject.courtyard.creatureGeneratorCommon.scaryCavity.name" : "恐怖谷",


### PR DESCRIPTION
Fixed an issue where different creature dwellings shared the same duplicate name. I have updated them with their correct titles to ensure they are consistent with the corresponding building names used inside towns.